### PR TITLE
Feature: Skip existing properties 

### DIFF
--- a/src/actions/updateProperty.ts
+++ b/src/actions/updateProperty.ts
@@ -10,12 +10,14 @@ import {parseTemplate} from '../utils/parseTemplate';
  * @param app The Obsidian app instance.
  * @param propertyName The name of the property to be updated.
  * @param template The template string containing placeholders.
+ * @param skipExisting If true, don't update properties that already exist.
  */
 export async function updateProperty(
 	file: TFile,
 	app: App,
 	propertyName?: string,
-	template?: string
+	template?: string,
+	skipExisting: boolean = false
 ): Promise<boolean> {
 
 	if (!app?.vault || !propertyName || !template) {
@@ -44,7 +46,7 @@ export async function updateProperty(
 
 	// Update property with the parsed template value.
 	try {
-		await propertyUpdater(file, app, propertyName, () => parsedTemplate);
+		await propertyUpdater(file, app, propertyName, () => parsedTemplate, skipExisting);
 		return true;
 	} catch (error) {
 		return false;

--- a/src/handlers/actionManager.ts
+++ b/src/handlers/actionManager.ts
@@ -24,7 +24,8 @@ export function actionManager(app: App, settings: SentinelPluginSettings) {
 						file,
 						app,
 						action.propertyName,
-						action.propertyValue
+						action.propertyValue,
+						action.skipExisting || false
 					);
 				} catch (error) {
 					new Notice(getLabel('failedUpdatingProperty', {

--- a/src/handlers/propertyUpdater.ts
+++ b/src/handlers/propertyUpdater.ts
@@ -5,11 +5,16 @@ export async function propertyUpdater(
 	file: TFile,
 	app: App,
 	propertyName: string,
-	updater: (currentValue: number | string) => number | string
+	updater: (currentValue: number | string) => number | string,
+	skipExisting: boolean = false
 ): Promise<boolean> {
 	try {
 		await app.fileManager.processFrontMatter(file, (frontmatter) => {
 			const currentValue = frontmatter[propertyName];
+
+			if (skipExisting && currentValue !== undefined) {
+				return;
+			}
 
 			if (typeof currentValue === 'boolean') {
 				new Notice(getLabel('failedUpdatingProperty', {

--- a/src/settings/settingsActions.ts
+++ b/src/settings/settingsActions.ts
@@ -84,6 +84,15 @@ export function addAction(
 					action.propertyValue = value;
 					await plugin.saveSettings();
 				})
+			 );
+
+		new Setting(actionContainer)
+			.setName('Skip Existing')
+			.addToggle((toggle) =>
+				toggle.setValue(action.skipExisting || false).onChange(async (value) => {
+					action.skipExisting = value;
+					await plugin.saveSettings();
+				})
 			);
 	} else {
 		new Setting(actionContainer)

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -5,6 +5,7 @@ interface Action {
 	propertyName?: string;
 	propertyValue?: string;
 	commandId?: string;
+	skipExisting?: boolean;
 }
 
 export interface SentinelPluginSettings {

--- a/styles.css
+++ b/styles.css
@@ -65,11 +65,15 @@
 
 	.sentinel--action-container .setting-item:nth-child(4),
 	.sentinel--action-container .setting-item:nth-child(5) {
-		width: calc(40% - 0.5em);
+		width: calc(33% - 0.5em);
 		margin-right: 0.75em;
 	}
-
-	.sentinel--action-container .setting-item:nth-child(5) {
+	
+	.sentinel--action-container .setting-item:nth-child(6) {
+		width: calc(14% - 0.5em);
 		margin-right: 0;
+	}
+	.sentinel--action-container .setting-item:nth-child(6) .setting-item-control {
+		width: fit-content;
 	}
 }


### PR DESCRIPTION
I added an option to skip existing properties (update only if currentValue !== undefined) so that the action creates a property only if it doesn’t already exist. This allows Sentinel to be used for things like file creation dates.

![image](https://github.com/user-attachments/assets/cd7a2338-498e-4662-af95-073318a64d1c)

### File changes

* [`src/actions/updateProperty.ts`](diffhunk://#diff-7e0f464840f0389ae00cb0c1e6cd24a2da9f406177bbe1b27696bc6f703fdfc5R13-R20): Added a new parameter `skipExisting` to the `updateProperty` function to allow skipping updates for properties that already exist. [[1]](diffhunk://#diff-7e0f464840f0389ae00cb0c1e6cd24a2da9f406177bbe1b27696bc6f703fdfc5R13-R20) [[2]](diffhunk://#diff-7e0f464840f0389ae00cb0c1e6cd24a2da9f406177bbe1b27696bc6f703fdfc5L47-R49)
* [`src/handlers/actionManager.ts`](diffhunk://#diff-866c58b637b86590336323ef04348b796429a7cd2a973e4e9cf9fd31ecc40cd6L27-R28): Updated the `actionManager` function to pass the `skipExisting` parameter to the `updateProperty` function.
* [`src/handlers/propertyUpdater.ts`](diffhunk://#diff-34d46e00fef543d19e2b4617048c737ec09a0170b388e60802afde4936d05963L8-R18): Modified the `propertyUpdater` function to include the `skipExisting` parameter and logic to skip updating existing properties.
* [`src/settings/settingsActions.ts`](diffhunk://#diff-39bd32b913d8df52883ca054c565a9536875d680fd5c961111bf0451e11cd7beR88-R96): Added a new toggle setting to the user interface to enable or disable the `skipExisting` option for actions.

### UI Adjustments

* [`styles.css`](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1L68-R78): Adjusted the CSS styles to accommodate the new toggle setting in the action container.